### PR TITLE
Iter constructs

### DIFF
--- a/examples/ticket_ordering.rs
+++ b/examples/ticket_ordering.rs
@@ -1,0 +1,135 @@
+#![feature(box_syntax)]
+
+extern crate rust_sessions;
+extern crate rand;
+
+use rust_sessions::*;
+
+use std::thread::spawn;
+use std::sync::mpsc::channel;
+use std::io::Write;
+
+use rand::{thread_rng, Rand};
+
+/*
+ * This is the type we need to implement (from Hu-Yoshida-Honda):
+ *
+ * protocol placeOrder {
+ *   begin.
+ *   ![ !<String>.?(Double) ]*.     // ![]* construct is iterating construct, a kind of rec-choose
+ *   !{ ACCEPT: !<Address>.?(Date), // !{} is branching construct (multi-way choose with labels)
+ *      REJECT:
+ *    }
+ * }
+ *
+ */
+
+type TravelAgency = IterOut<Recv<String, Send<f64, IterEps>>, Offer<Recv<String, Send<u64, Eps>>, Eps>>;
+type Client = IterIn<Send<String, Recv<f64, IterEps>>, Choose<Send<String, Recv<u64, Eps>>, Eps>>;
+
+macro_rules! query {
+    ($q:expr) => ({
+        print!($q);
+        let _ = std::io::stdout().flush();
+    })
+}
+
+fn cli(c: Chan<(), Client>) {
+
+    let mut buf = "".to_string();
+    let mut stdin = std::io::stdin();
+    let mut loop_chan = c;
+    let end;
+    loop {
+        query!("Another query? (Y/n) ");
+
+        buf.clear();
+        stdin.read_line(&mut buf).ok().unwrap();
+
+        match &buf[..] {
+            "n\n" | "N\n" | "n" | "N" => {
+                end = loop_chan.exit_while();
+                break
+            }
+            _ => {
+                let c = loop_chan.in_while();
+                buf.clear();
+                query!("Query: ");
+
+                stdin.read_line(&mut buf).ok().unwrap();
+                let c = c.send(buf.clone());
+                let (c, price) = c.recv();
+                println!("That costs {}", price);
+
+                loop_chan = c.iter();
+            }
+        }
+    }
+
+    query!("Accept? (Y/n) ");
+    buf.clear();
+    stdin.read_line(&mut buf).ok().unwrap();
+    match &buf[..] {
+        "n\n" | "N\n" => {
+            println!("Bye");
+            end.sel2().close();
+        }
+        _ => {
+            query!("Delivery address: ");
+
+            buf.clear();
+            stdin.read_line(&mut buf).ok().unwrap();
+
+            let (c, date) = end.sel1().send(buf).recv();
+            println!("Dispatch date: {}", date);
+            println!("Nice doing business with you, bye!");
+            c.close();
+        }
+    }
+}
+
+fn srv(c: Chan<(), TravelAgency>) {
+
+    let mut g = thread_rng();
+
+    let end;
+    let mut loop_chan: Chan<(), TravelAgency> = c;
+
+    loop {
+        let c = match loop_chan.out_while() {
+            Ok(c) => c,
+            Err(c) => { end = c; break }
+        };
+        let (c, _) = c.recv();
+        loop_chan = c.send(Rand::rand(&mut g)).iter();
+    }
+
+    // Alternative formulation - note that this version doesn't work, since the
+    // typing cannot infer the resulting loop is the same as above.
+    // while let Some(c) = match loop_chan.out_while() {
+    //     Ok(c) => Some(c),
+    //     Err(c) => { end = c; None }
+    // } {
+    //     let (c, _) = c.recv();
+    //     loop_chan = c.send(Rand::rand(&mut g)).iter();
+    // }
+
+    match end.offer() {
+        Ok(c) => {
+            // Receive address and send date
+            let (c, _) = c.recv();
+            c.send(Rand::rand(&mut g)).close();
+        }
+        Err(c) => {
+            // Declined
+            c.close();
+        }
+    }
+}
+
+fn main() {
+    let (travel_agency, client) = session_channel();
+
+    spawn(move || srv(travel_agency));
+    cli(client);
+}


### PR DESCRIPTION
This adds iteration constructs to the session type "DSL". Specifically three new structs are added with matching dual implementations (phantom data markers omitted):

```rust
struct IterOut<R, N>;
struct IterIn<R, N>;
struct IterEps;

impl<R: HasDual, N: HasDual> HasDual for IterOut<R, N> {
    type Dual = IterIn<R::Dual, N::Dual>;
}
```
with a mirror implementation for `IterIn`. `IterEps` is its own dual.

The idea is that `R` may be repeated zero or more times, where the party with the `IterOut` construct decides whether to iterate or not (better names for the structs are welcome).

`IterOut` allows two functions:
```rust
impl<E, R, N> Chan<E, IterOut<R, N>> {
    pub fn in_while(self) -> Chan<(IterOut<R, N>, E), R> { ... }
    pub fn exit_while(self) -> Chan<E, N> { ... }
}
``` 
where the implementation communicates the decision to the other party (as a boolean). `IterIn` then obtains the decision to iterate or not and must act accordingly.

```rust
impl<E, R, N> Chan<E, IterIn<R, N>> {
    pub fn out_while(self) -> Result<Chan<(IterIn<R, N>, E), R>, Chan<E, N>> { ... }
}
```
The inner body of the recursive construct (denoted `R` above) must indicate its end using `IterEps`.
```rust
impl<E, R> Chan<(R, E), IterEps> {
    pub fn iter(self) -> Chan<E, R> { ... }
}
```

----

Semantically, the iteration constructs are equivalent to a `Rec<Choose<P, R>>` construct, but where the `Rec` struct lacks a notion of a "next" action, the iteration construct provides this as the second type parameter (`N` above).

Note that there is no gain in expressivity! Any program using `Rec<Choose<P, R>>` can be rewritten to use `IterIn`/`IterOut` (but not the reverse - see the discussion below), but the lack of sequencing in `Rec` may be jarring to some users. I would suggest that we only provide one of these constructs though!

EDIT: Update based on discussion below