### PR TITLE
Fix fallout from upgrade to latest nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@
 //! }
 //! ```
 
-#![feature(std_misc)]
+#![feature(mpsc_select)]
 
 use std::marker;
 use std::thread::spawn;


### PR DESCRIPTION
 - `std_misc` no longer a recognised feature
 - `mpsc_select` feature required for using Select