### PR TITLE
Added .pop() to Chan as a complete alternative to .succ() and .zero().

### DIFF
--- a/tests/pop.rs
+++ b/tests/pop.rs
@@ -1,0 +1,15 @@
+extern crate session_types;
+use session_types::*;
+
+fn client(n: u64, mut c: Chan<(), Rec<Send<u64, Var<Z>>>>) {
+    let mut c = c.enter();
+    c = c.send(n).pop(); // type should remain the same, test will fail if it cannot compile
+}
+
+fn client2(n: u64, mut c: Chan<(), Rec<Send<u64, Rec<Send<u64, Var<S<Z>>>>>>>) {
+    let mut c = c.enter();
+    c = c.send(n).enter().send(n).pop(); // type should remain the same, test will fail if it cannot compile
+}
+
+#[test]
+fn main() {}


### PR DESCRIPTION
`.pop()` will automatically bring the type upward from the "recursive" depth indicated by Var<N>, obviating the need for `.succ().succ().succ().zero()` or similar things.

Closes #25 