### PR TITLE
check protocol completion at compile time

### DIFF
--- a/examples/connect.rs
+++ b/examples/connect.rs
@@ -1,12 +1,12 @@
 extern crate session_types;
 use session_types::*;
 
-fn server(c: Chan<(), Eps>) {
-    c.close()
+fn server<'run>(c: Chan2<'run, (), Eps>) -> Complete<'run, Eps> {
+    return c.close()
 }
 
-fn client(c: Chan<(), Eps>) {
-    c.close()
+fn client<'run>(c: Chan2<'run, (), Eps>) -> Complete<'run, Eps> {
+    return c.close()
 }
 
 fn main() {

--- a/examples/generic.rs
+++ b/examples/generic.rs
@@ -8,14 +8,14 @@ use session_types::*;
 
 use std::thread::spawn;
 
-fn srv<A: std::marker::Send+'static>(x: A, c: Chan<(), Send<A, Eps>>) {
-    c.send(x).close();
+fn srv<'run, A: std::marker::Send+'static>(x: A, c: Chan2<'run, (), Send<A, Eps>>) -> Complete<'run, Send<A, Eps>> {
+    return c.send(x).close();
 }
 
-fn cli<A: std::marker::Send+std::fmt::Debug+'static>(c: Chan<(), Recv<A, Eps>>) {
+fn cli<'run, A: std::marker::Send+std::fmt::Debug+'static>(c: Chan2<'run, (), Recv<A, Eps>>) -> Complete<'run, Recv<A, Eps>> {
     let (c, x) = c.recv();
     println!("{:?}", x);
-    c.close();
+    return c.close();
 }
 
 fn main() {

--- a/tests/chan_select.rs
+++ b/tests/chan_select.rs
@@ -96,10 +96,10 @@ fn chan_select_add_ret() {
 
 // Utility functions
 
-fn send_str(c: Chan<(), Send<String, Eps>>) {
-    c.send("Hello, World!".to_string()).close();
+fn send_str<'run, TopP>(c: Chan<'run, TopP, (), Send<String, Eps>>) -> Complete<'run, TopP> {
+    return c.send("Hello, World!".to_string()).close();
 }
 
-fn send_usize(c: Chan<(), Send<usize, Eps>>) {
-    c.send(42).close();
+fn send_usize<'run, TopP>(c: Chan<'run, TopP, (), Send<usize, Eps>>) -> Complete<'run, TopP> {
+    return c.send(42).close();
 }

--- a/tests/compile-fail/complete.rs
+++ b/tests/compile-fail/complete.rs
@@ -1,0 +1,14 @@
+extern crate session_types;
+use session_types::*;
+
+type Messenger = Send<i64, Send<bool, Eps>>;
+
+fn send_some_send_all<'run_some, 'run_all>(c1: Chan2<'run_some, (), Messenger>, c2: Chan2<'run_all, (), Messenger>) -> Complete<'run_some, Messenger> {
+    return c2.send(1).send(true).close(); //~ ERROR
+}
+
+fn main() {
+    let (tx1, _) = session_channel();
+    let (tx2, _) = session_channel();
+    send_some_send_all(tx1, tx2);
+}

--- a/tests/compile-fail/incompatible-sessions.rs
+++ b/tests/compile-fail/incompatible-sessions.rs
@@ -5,7 +5,7 @@ use std::sync::mpsc::channel;
 
 use session_types::*;
 
-fn srv(c: Chan<(), Recv<u8, Eps>>) {
+fn srv(c: Chan2<'static, (), Recv<u8, Eps>>) {
     let (c, x) = c.recv();
     c.close();
 }

--- a/tests/compile-fail/no-aliasing.rs
+++ b/tests/compile-fail/no-aliasing.rs
@@ -5,7 +5,7 @@ use std::sync::mpsc::channel;
 
 use session_types::*;
 
-fn srv(c: Chan<(), Recv<u8, Eps>>) {
+fn srv(c: Chan2<'static, (), Recv<u8, Eps>>) {
     let (c, x) = c.recv();
     c.close();
 }

--- a/tests/compile-fail/send-on-recv.rs
+++ b/tests/compile-fail/send-on-recv.rs
@@ -7,11 +7,11 @@ use session_types::*;
 
 type Proto = Send<u8, Eps>;
 
-fn srv(c: Chan<(), Proto>) {
+fn srv(c: Chan2<'static, (), Proto>) {
     c.send(42).close();
 }
 
-fn cli(c: Chan<(), <Proto as HasDual>::Dual>) {
+fn cli(c: Chan2<'static, (), <Proto as HasDual>::Dual>) {
     c.send(42).close(); //~ ERROR
 }
 

--- a/tests/send_recv.rs
+++ b/tests/send_recv.rs
@@ -3,7 +3,7 @@ use session_types::*;
 
 use std::thread::spawn;
 
-fn client(n: u64, c: Chan<(), Send<u64, Eps>>) {
+fn client<'run>(n: u64, c: Chan2<'run, (), Send<u64, Eps>>) -> Complete<'run, Send<u64, Eps>> {
     c.send(n).close()
 }
 


### PR DESCRIPTION
destructor bomb alternative

features:
- check that your implementation always runs to completion

```rust
extern crate session_types;
use session_types::*;

type Messenger = Send<i64, Send<bool, Eps>>;

fn send_all(c: ChanS<(), Messenger>) -> Complete<'static, Messenger> {
    return c.send(1).send(true).close();
}
```

- check that your implementation runs the correct instance
```rust
extern crate session_types;
use session_types::*;

type Messenger = Send<i64, Send<i64, Send<bool, Eps>>>;

fn send_some<'send_one, 'send_two>(
c1: Chan2<'send_one, (), Messenger>,
c2: Chan2<'send_two, (), Messenger>)
-> (
      Chan<'send_one, Messenger, (), Send<i64, Send<bool, Eps>>>,
      Chan<'send_two, Messenger, (), Send<bool, Eps>>
) {
    return (c1.send(1), c2.send(1).send(2));
}
```
known problems:
- chan_select! macro is broken, and I don't know enough to fix it
- the Complete<> type should be limited somehow