### PR TITLE
Allow building on stable rust by making chan_select an optional feature.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
 
 env:
   global:
-    - TRAVIS_CARGO_NIGHTLY_FEATURE=channel_select
+    - TRAVIS_CARGO_NIGHTLY_FEATURE=chan_select
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,22 @@
 language: rust
 
 rust:
-    - nightly
+  - stable
+  - beta
+  - nightly
+
+before_script:
+  - |
+    pip install 'travis-cargo<0.2' --user &&
+    export PATH=$HOME/.local.bin:$PATH
+script:
+  - |
+    travis-cargo build &&
+    travis-cargo test
+
+env:
+  global:
+    - TRAVIS_CARGO_NIGHTLY_FEATURE=channel_select
 
 notifications:
   email:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ rand = "*"
 compiletest_rs = "*"
 
 [features]
-channel_select = []
+chan_select = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,10 @@ license = "MIT"
 
 [dev-dependencies]
 rand = "*"
-compiletest_rs = "*"
 
 [features]
-chan_select = []
+default = []
+chan_select = ["compiletest_rs"]
+
+[dependencies]
+compiletest_rs = { version = "*", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "session_types"
-version = "0.1.1"
+version = "0.2.1"
 authors = [ "Philip Munksgaard <pmunksgaard@gmail.com>"
           , "Thomas Bracht Laumann Jespersen <laumann.thomas@gmail.com>"
           ]
@@ -16,3 +16,6 @@ license = "MIT"
 rand = "*"
 rand_macros = "*"
 compiletest_rs = "*"
+
+[features]
+channel_select = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ license = "MIT"
 
 [dev-dependencies]
 rand = "*"
-rand_macros = "*"
 compiletest_rs = "*"
 
 [features]

--- a/examples/echo-server.rs
+++ b/examples/echo-server.rs
@@ -32,7 +32,7 @@ fn srv(c: Chan<(), Rec<Srv>>) {
 type Cli = <Srv as HasDual>::Dual;
 fn cli(c: Chan<(), Rec<Cli>>) {
 
-    let mut stdin = std::io::stdin();
+    let stdin = std::io::stdin();
     let mut count = 0usize;
 
     let mut c = c.enter();

--- a/examples/planeclip.rs
+++ b/examples/planeclip.rs
@@ -5,21 +5,32 @@
 // The implementation borrows heavily from Pucella-Tov (2008). See that paper
 // for more explanation.
 
-#![feature(plugin, custom_derive)]
-#![plugin(rand_macros)]
-
 extern crate session_types;
 extern crate rand;
 
 use session_types::*;
 
+use rand::{Rand, Rng};
+
 use std::thread::spawn;
 
-#[derive(Debug, Copy, Clone, Rand)]
+#[derive(Debug, Copy, Clone)]
 struct Point(f64, f64, f64);
 
-#[derive(Debug, Copy, Clone, Rand)]
+impl Rand for Point {
+    fn rand<R: Rng>(rng: &mut R) -> Self {
+        Point(rng.next_f64(), rng.next_f64(), rng.next_f64())
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
 struct Plane(f64, f64, f64, f64);
+
+impl Rand for Plane {
+    fn rand<R: Rng>(rng: &mut R) -> Self {
+        Plane(rng.next_f64(), rng.next_f64(), rng.next_f64(), rng.next_f64())
+    }
+}
 
 fn above(Point(x, y, z): Point, Plane(a, b, c, d): Plane) -> bool {
     (a * x + b * y + c * z + d) / (a * a + b * b + c * c).sqrt() > 0.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@
 //! }
 //! ```
 
-#![cfg_attr(feature = "channel_select", feature(mpsc_select))]
+#![cfg_attr(feature = "chan_select", feature(mpsc_select))]
 
 use std::marker;
 use std::thread::spawn;
@@ -68,9 +68,9 @@ use std::mem::transmute;
 use std::sync::mpsc::{Sender, Receiver, channel};
 use std::marker::PhantomData;
 
-#[cfg(feature = "channel_select")]
+#[cfg(feature = "chan_select")]
 use std::sync::mpsc::Select;
-#[cfg(feature = "channel_select")]
+#[cfg(feature = "chan_select")]
 use std::collections::HashMap;
 
 pub use Branch::*;
@@ -320,7 +320,7 @@ impl<E, P, N> Chan<(P, E), Var<S<N>>> {
 /// protocol (and in the exact same point of the protocol), wait for one of them
 /// to receive. Removes the receiving channel from the vector and returns both
 /// the channel and the new vector.
-#[cfg(feature = "channel_select")]
+#[cfg(feature = "chan_select")]
 #[must_use]
 pub fn hselect<E, P, A>(mut chans: Vec<Chan<E, Recv<A, P>>>)
                         -> (Chan<E, Recv<A, P>>, Vec<Chan<E, Recv<A, P>>>)
@@ -332,7 +332,7 @@ pub fn hselect<E, P, A>(mut chans: Vec<Chan<E, Recv<A, P>>>)
 
 /// An alternative version of homogeneous select, returning the index of the Chan
 /// that is ready to receive.
-#[cfg(feature = "channel_select")]
+#[cfg(feature = "chan_select")]
 pub fn iselect<E, P, A>(chans: &Vec<Chan<E, Recv<A, P>>>) -> usize {
     let mut map = HashMap::new();
 
@@ -371,12 +371,12 @@ pub fn iselect<E, P, A>(chans: &Vec<Chan<E, Recv<A, P>>>) -> usize {
 ///
 /// The type parameter T is a return type, ie we store a value of some type T
 /// that is returned in case its associated channels is selected on `wait()`
-#[cfg(feature = "channel_select")]
+#[cfg(feature = "chan_select")]
 pub struct ChanSelect<'c, T> {
     chans: Vec<(&'c Chan<(), ()>, T)>,
 }
 
-#[cfg(feature = "channel_select")]
+#[cfg(feature = "chan_select")]
 impl<'c, T> ChanSelect<'c, T> {
     pub fn new() -> ChanSelect<'c, T> {
         ChanSelect {
@@ -440,7 +440,7 @@ impl<'c, T> ChanSelect<'c, T> {
 /// Default use of ChanSelect works with usize and returns the index
 /// of the selected channel. This is also the implementation used by
 /// the `chan_select!` macro.
-#[cfg(feature = "channel_select")]
+#[cfg(feature = "chan_select")]
 impl<'c> ChanSelect<'c, usize> {
     pub fn add_recv<E, P, A: marker::Send>(&mut self,
                                            c: &'c Chan<E, Recv<A, P>>)
@@ -635,7 +635,7 @@ macro_rules! offer {
 ///     srv(ca1, cb1);
 /// }
 /// ```
-#[cfg(features = "channel_select")]
+#[cfg(features = "chan_select")]
 #[macro_export]
 macro_rules! chan_select {
     (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,9 +283,9 @@ impl<E, P, Q> Chan<E, Offer<P, Q>> {
         unsafe {
             let b = read_chan(&self);
             if b {
-                Branch::Left(transmute(self))
+                Left(transmute(self))
             } else {
-                Branch::Right(transmute(self))
+                Right(transmute(self))
             }
         }
     }
@@ -531,8 +531,8 @@ macro_rules! offer {
         $id:ident, $branch:ident => $code:expr, $($t:tt)+
     ) => (
         match $id.offer() {
-            Branch::Left($id) => $code,
-            Branch::Right($id) => offer!{ $id, $($t)+ }
+            Left($id) => $code,
+            Right($id) => offer!{ $id, $($t)+ }
         }
     );
     (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,14 +60,18 @@
 //! }
 //! ```
 
-#![feature(mpsc_select)]
+#![cfg_attr(feature = "channel_select", feature(mpsc_select))]
 
 use std::marker;
 use std::thread::spawn;
 use std::mem::transmute;
-use std::sync::mpsc::{Sender, Receiver, channel, Select};
-use std::collections::HashMap;
+use std::sync::mpsc::{Sender, Receiver, channel};
 use std::marker::PhantomData;
+
+#[cfg(feature = "channel_select")]
+use std::sync::mpsc::Select;
+#[cfg(feature = "channel_select")]
+use std::collections::HashMap;
 
 pub use Branch::*;
 
@@ -316,6 +320,7 @@ impl<E, P, N> Chan<(P, E), Var<S<N>>> {
 /// protocol (and in the exact same point of the protocol), wait for one of them
 /// to receive. Removes the receiving channel from the vector and returns both
 /// the channel and the new vector.
+#[cfg(feature = "channel_select")]
 #[must_use]
 pub fn hselect<E, P, A>(mut chans: Vec<Chan<E, Recv<A, P>>>)
                         -> (Chan<E, Recv<A, P>>, Vec<Chan<E, Recv<A, P>>>)
@@ -327,6 +332,7 @@ pub fn hselect<E, P, A>(mut chans: Vec<Chan<E, Recv<A, P>>>)
 
 /// An alternative version of homogeneous select, returning the index of the Chan
 /// that is ready to receive.
+#[cfg(feature = "channel_select")]
 pub fn iselect<E, P, A>(chans: &Vec<Chan<E, Recv<A, P>>>) -> usize {
     let mut map = HashMap::new();
 
@@ -365,11 +371,12 @@ pub fn iselect<E, P, A>(chans: &Vec<Chan<E, Recv<A, P>>>) -> usize {
 ///
 /// The type parameter T is a return type, ie we store a value of some type T
 /// that is returned in case its associated channels is selected on `wait()`
+#[cfg(feature = "channel_select")]
 pub struct ChanSelect<'c, T> {
     chans: Vec<(&'c Chan<(), ()>, T)>,
 }
 
-
+#[cfg(feature = "channel_select")]
 impl<'c, T> ChanSelect<'c, T> {
     pub fn new() -> ChanSelect<'c, T> {
         ChanSelect {
@@ -433,6 +440,7 @@ impl<'c, T> ChanSelect<'c, T> {
 /// Default use of ChanSelect works with usize and returns the index
 /// of the selected channel. This is also the implementation used by
 /// the `chan_select!` macro.
+#[cfg(feature = "channel_select")]
 impl<'c> ChanSelect<'c, usize> {
     pub fn add_recv<E, P, A: marker::Send>(&mut self,
                                            c: &'c Chan<E, Recv<A, P>>)
@@ -627,8 +635,7 @@ macro_rules! offer {
 ///     srv(ca1, cb1);
 /// }
 /// ```
-
-
+#[cfg(features = "channel_select")]
 #[macro_export]
 macro_rules! chan_select {
     (

--- a/tests/chan_select.rs
+++ b/tests/chan_select.rs
@@ -1,14 +1,14 @@
 #[macro_use] extern crate session_types;
 
-#[cfg(feature = "channel_select")]
+#[cfg(feature = "chan_select")]
 use std::thread::spawn;
-#[cfg(feature = "channel_select")]
+#[cfg(feature = "chan_select")]
 use std::borrow::ToOwned;
-#[cfg(feature = "channel_select")]
+#[cfg(feature = "chan_select")]
 use session_types::*;
 
 // recv and assert a value, then close the channel
-#[cfg(feature = "channel_select")]
+#[cfg(feature = "chan_select")]
 macro_rules! recv_assert_eq_close(
     ($e:expr, $rx:ident.recv())
         =>
@@ -19,7 +19,7 @@ macro_rules! recv_assert_eq_close(
     })
 );
 
-#[cfg(feature = "channel_select")]
+#[cfg(feature = "chan_select")]
 #[test]
 fn chan_select_simple() {
     let (tcs, rcs) = session_channel();
@@ -62,7 +62,7 @@ fn chan_select_simple() {
     recv_assert_eq_close!("Hello, World!".to_owned(), rcs.recv());
 }
 
-#[cfg(feature = "channel_select")]
+#[cfg(feature = "chan_select")]
 #[test]
 fn chan_select_add_ret() {
     enum ChanToRead {
@@ -102,12 +102,12 @@ fn chan_select_add_ret() {
 
 // Utility functions
 
-#[cfg(feature = "channel_select")]
+#[cfg(feature = "chan_select")]
 fn send_str(c: Chan<(), Send<String, Eps>>) {
     c.send("Hello, World!".to_string()).close();
 }
 
-#[cfg(feature = "channel_select")]
+#[cfg(feature = "chan_select")]
 fn send_usize(c: Chan<(), Send<usize, Eps>>) {
     c.send(42).close();
 }

--- a/tests/chan_select.rs
+++ b/tests/chan_select.rs
@@ -1,10 +1,14 @@
 #[macro_use] extern crate session_types;
 
+#[cfg(feature = "channel_select")]
 use std::thread::spawn;
+#[cfg(feature = "channel_select")]
 use std::borrow::ToOwned;
+#[cfg(feature = "channel_select")]
 use session_types::*;
 
 // recv and assert a value, then close the channel
+#[cfg(feature = "channel_select")]
 macro_rules! recv_assert_eq_close(
     ($e:expr, $rx:ident.recv())
         =>
@@ -15,6 +19,7 @@ macro_rules! recv_assert_eq_close(
     })
 );
 
+#[cfg(feature = "channel_select")]
 #[test]
 fn chan_select_simple() {
     let (tcs, rcs) = session_channel();
@@ -57,6 +62,7 @@ fn chan_select_simple() {
     recv_assert_eq_close!("Hello, World!".to_owned(), rcs.recv());
 }
 
+#[cfg(feature = "channel_select")]
 #[test]
 fn chan_select_add_ret() {
     enum ChanToRead {
@@ -96,10 +102,12 @@ fn chan_select_add_ret() {
 
 // Utility functions
 
+#[cfg(feature = "channel_select")]
 fn send_str(c: Chan<(), Send<String, Eps>>) {
     c.send("Hello, World!".to_string()).close();
 }
 
+#[cfg(feature = "channel_select")]
 fn send_usize(c: Chan<(), Send<usize, Eps>>) {
     c.send(42).close();
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,7 +1,10 @@
+#[cfg(feature = "chan_select")]
 extern crate compiletest_rs as compiletest;
 
+#[cfg(feature = "chan_select")]
 use std::path::PathBuf;
 
+#[cfg(feature = "chan_select")]
 fn run_mode(mode: &'static str) {
     let mut config = compiletest::default_config();
     let cfg_mode = mode.parse().ok().expect("Invalid mode");
@@ -13,6 +16,7 @@ fn run_mode(mode: &'static str) {
     compiletest::run_tests(&config);
 }
 
+#[cfg(feature = "chan_select")]
 #[test]
 fn compile_test() {
     run_mode("compile-fail");


### PR DESCRIPTION
This allows session-types to build on stable Rust 1.4, while preserving the chan_select features for people who need them and don't mind being on nightly. Compiling with this feature is simply:

    cargo build --features channel_select

and including session-types as a dependency with this feature:

    [dependencies]
    session_types = { version = "0.2.1", features = ["channel_select"] }

I also incremented the minor version number since this is a breaking change for users who already use the feature - they'll need to update their dependency listing to include the feature.

Travis, using the current yaml, will not test with the feature present. I can add a change to fix that if you'd like.