### PR TITLE
Add try_* operations for recv and offer

### DIFF
--- a/examples/try-offer.rs
+++ b/examples/try-offer.rs
@@ -1,0 +1,64 @@
+//! A variation of the echo server where the server wakes up every 20ms
+//! and polls for pending messages (single characters in this case): here
+//! the "server" echos the received character after converting to uppercase,
+//! and the "client" generates a some characters at different intervals.
+
+#[macro_use] extern crate session_types;
+use session_types::*;
+
+type Term = Eps;
+
+type Upcase = Offer <
+    Recv <char, Var <Z>>,
+    Term
+>;
+
+type Chargen = <Upcase as HasDual>::Dual;
+
+fn upcase (chan : Chan <(), Rec <Upcase>>) {
+    let mut chan = chan.enter();
+    'outer: loop {
+        println!("upcase: tick!");
+        let mut poll = true;
+        while poll {
+            let result = try_offer!{ chan,
+                ACHAR => {
+                    let (chan, ch) = chan.recv();
+                    println!("{:?}", ch.to_uppercase().next().unwrap());
+                    Ok (chan.zero())
+                },
+                QUIT => {
+                    chan.close();
+                    break 'outer
+                }
+            };
+            chan = match result {
+                Ok    (chan) => chan,
+                Err (chan) => {
+                    poll = false;
+                    chan
+                }
+            }
+        }
+        std::thread::sleep (std::time::Duration::from_millis (20));
+    }
+}
+
+fn chargen (chan : Chan <(), Rec <Chargen>>) {
+    let mut chan = chan.enter();
+    chan = chan.sel1().send ('a').zero();
+    chan = chan.sel1().send ('b').zero();
+    chan = chan.sel1().send ('c').zero();
+    std::thread::sleep (std::time::Duration::from_millis (100));
+    chan = chan.sel1().send ('d').zero();
+    std::thread::sleep (std::time::Duration::from_millis (100));
+    chan = chan.sel1().send ('e').zero();
+    chan.sel2().close();
+}
+
+fn main() {
+    let (chan1, chan2) = session_channel();
+    let join_handle = std::thread::spawn (move || upcase (chan1));
+    chargen (chan2);
+    join_handle.join().unwrap();
+}

--- a/tests/try_recv.rs
+++ b/tests/try_recv.rs
@@ -1,0 +1,28 @@
+extern crate session_types;
+use session_types::*;
+
+use std::thread::spawn;
+
+fn client(n: u64, c: Chan<(), Send<u64, Eps>>) {
+    c.send(n).close()
+}
+
+#[test]
+fn main() {
+    let n = 42;
+    let (c1, c2) = session_channel();
+
+    let res = c2.try_recv();
+    assert!(res.is_err());
+    let c2 = res.err().unwrap();
+
+    let client_thread = spawn(move || client(n, c1));
+    client_thread.join().unwrap();
+
+    let res = c2.try_recv();
+    assert!(res.is_ok());
+    let (c, n_) = res.ok().unwrap();
+    assert_eq!(n, n_);
+
+    c.close();
+}


### PR DESCRIPTION
New methods for `try_recv` and `try_offer` rely on new internal method `try_read_chan` that calls  `mpsc::try_recv` and returns an option containing the value if one was pending, and panicking if the channel was closed prematurely.

The `offer!` macro is adapted to the `try_offer!` macro which returns the unmodified channel wrapped in `Err` if no messages were pending. This means the user-defined branches need to return a result, namely the new channel in the chosen branch wrapped in `Ok`. 