### PR TITLE
Fix failing travis build

### DIFF
--- a/tests/compile-fail/incompatible-sessions.rs
+++ b/tests/compile-fail/incompatible-sessions.rs
@@ -1,7 +1,6 @@
 extern crate session_types;
 
 use std::thread::spawn;
-use std::sync::mpsc::channel;
 
 use session_types::*;
 

--- a/tests/compile-fail/no-aliasing.rs
+++ b/tests/compile-fail/no-aliasing.rs
@@ -1,12 +1,11 @@
 extern crate session_types;
 
 use std::thread::spawn;
-use std::sync::mpsc::channel;
 
 use session_types::*;
 
 fn srv(c: Chan<(), Recv<u8, Eps>>) {
-    let (c, x) = c.recv();
+    let (c, _) = c.recv();
     c.close();
 }
 

--- a/tests/compile-fail/send-on-recv.rs
+++ b/tests/compile-fail/send-on-recv.rs
@@ -1,7 +1,6 @@
 extern crate session_types;
 
 use std::thread::spawn;
-use std::sync::mpsc::channel;
 
 use session_types::*;
 


### PR DESCRIPTION
This fixes some compiletest warnings that caused builds to fail on travis.

In particular, the following failure is caused by these warnings:
https://travis-ci.org/Munksgaard/session-types/jobs/267863186