### PR TITLE
Prepend $crate:: to the Left and Right branches in offer! and try_offer! macros

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -601,8 +601,8 @@ macro_rules! offer {
         $id:ident, $branch:ident => $code:expr, $($t:tt)+
     ) => (
         match $id.offer() {
-            Left($id) => $code,
-            Right($id) => offer!{ $id, $($t)+ }
+            $crate::Left($id) => $code,
+            $crate::Right($id) => offer!{ $id, $($t)+ }
         }
     );
     (
@@ -619,8 +619,8 @@ macro_rules! try_offer {
         $id:ident, $branch:ident => $code:expr, $($t:tt)+
     ) => (
         match $id.try_offer() {
-            Ok(Left($id)) => $code,
-            Ok(Right($id)) => try_offer!{ $id, $($t)+ },
+            Ok($crate::Left($id)) => $code,
+            Ok($crate::Right($id)) => try_offer!{ $id, $($t)+ },
             Err($id) => Err($id)
         }
     );


### PR DESCRIPTION
This should obviate the need to explicitly `use session_types::Branch;` at the macro invocation site.