### PR TITLE
Handle some of the  reported by clippy

### DIFF
--- a/examples/arithmetic.rs
+++ b/examples/arithmetic.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(feature = "cargo-clippy", allow(type_complexity))]
 // This is an implementation of the extended arithmetic server from
 // Vasconcelos-Gay-Ravara (2006) with some additional functionality
 

--- a/examples/atm.rs
+++ b/examples/atm.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(feature = "cargo-clippy", allow(ptr_arg))]
 #[macro_use]
 extern crate session_types;
 use session_types::*;

--- a/examples/many-clients.rs
+++ b/examples/many-clients.rs
@@ -1,4 +1,4 @@
-
+#![cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
 extern crate rand;
 extern crate session_types;
 

--- a/examples/many-clients.rs
+++ b/examples/many-clients.rs
@@ -20,14 +20,9 @@ fn server_handler(c: Chan<(), Server>) {
 
 fn server(rx: Receiver<Chan<(), Server>>) {
     let mut count = 0;
-    loop {
-        match rx.recv() {
-            Ok(c) => {
-                spawn(move || server_handler(c));
-                count += 1;
-            }
-            Err(_) => break,
-        }
+    while let Ok(c) = rx.recv() {
+        spawn(move || server_handler(c));
+        count += 1;
     }
     println!("Handled {} connections", count);
 }

--- a/examples/planeclip.rs
+++ b/examples/planeclip.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(feature = "cargo-clippy", allow(many_single_char_names, ptr_arg))]
 // This is an implementation of the Sutherland-Hodgman (1974) reentrant polygon
 // clipping algorithm. It takes a polygon represented as a number of vertices
 // and cuts it according to the given planes.

--- a/examples/planeclip.rs
+++ b/examples/planeclip.rs
@@ -60,9 +60,9 @@ fn intersect(p1: Point, p2: Point, plane: Plane) -> Option<Point> {
 type SendList<A> = Rec<Choose<Eps, Send<A, Var<Z>>>>;
 type RecvList<A> = Rec<Offer<Eps, Recv<A, Var<Z>>>>;
 
-fn sendlist<A: std::marker::Send + Copy + 'static>(c: Chan<(), SendList<A>>, xs: Vec<A>) {
+fn sendlist<A: std::marker::Send + Copy + 'static>(c: Chan<(), SendList<A>>, xs: &Vec<A>) {
     let mut c = c.enter();
-    for x in xs.iter() {
+    for x in xs {
         let c1 = c.sel2().send(*x);
         c = c1.zero();
     }
@@ -135,10 +135,10 @@ fn clipper(plane: Plane, ic: Chan<(), RecvList<Point>>, oc: Chan<(), SendList<Po
 
 fn clipmany(planes: Vec<Plane>, points: Vec<Point>) -> Vec<Point> {
     let (tx, rx) = session_channel();
-    spawn(move || sendlist(tx, points));
+    spawn(move || sendlist(tx, &points));
     let mut rx = rx;
 
-    for plane in planes.into_iter() {
+    for plane in planes {
         let (tx2, rx2) = session_channel();
         spawn(move || clipper(plane, rx, tx2));
         rx = rx2;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@
 //! }
 //! ```
 #![cfg_attr(feature = "chan_select", feature(mpsc_select))]
+#![cfg_attr(feature = "cargo-clippy", allow(type_complexity))]
 
 use std::marker;
 use std::thread::spawn;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! session_types
+//! `session_types`
 //!
 //! This is an implementation of *session types* in Rust.
 //!

--- a/tests/chan_select.rs
+++ b/tests/chan_select.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate session_types;
 
 #[cfg(feature = "chan_select")]


### PR DESCRIPTION
 * Markdown format doc title
 * Change loop {} to while let .. {}
 * Remove unused #[macro_use]
 * Change owned args to borrowed in some places

Fixes #37