### PR TITLE
Fix version of compiletest to 0.3.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ default = []
 chan_select = ["compiletest_rs"]
 
 [dependencies]
-compiletest_rs = { version = "*", optional = true }
+compiletest_rs = { version = "0.3.11", optional = true }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 #[cfg(feature = "chan_select")]
 fn run_mode(mode: &'static str) {
-    let mut config = compiletest::default_config();
+    let mut config = compiletest::Config::default();
     let cfg_mode = mode.parse().ok().expect("Invalid mode");
 
     config.mode = cfg_mode;


### PR DESCRIPTION
Instead of using "*" for compiletest, fix it to the latest version. This
should ensure that "cargo +nightly test" always works provided the rustc
version has not changed.