### PR TITLE
Suggestion: User provided Message types

### DIFF
--- a/tests/send_recv.rs
+++ b/tests/send_recv.rs
@@ -3,7 +3,12 @@ use session_types::*;
 
 use std::thread::spawn;
 
-fn client(n: u64, c: Chan<(), Send<u64, Eps>>) {
+enum Msg {
+    U64(u64)
+}
+
+fn client(n: u64, c: Chan<(), Send<Msg, Eps>, Msg>) {
+    let n = Msg::U64(n);
     c.send(n).close()
 }
 
@@ -13,7 +18,7 @@ fn main() {
     let (c1, c2) = session_channel();
     spawn(move || client(n, c1));
 
-    let (c, n_) = c2.recv();
+    let (c, Msg::U64(n_)) = c2.recv();
     c.close();
     assert_eq!(n, n_);
 }

--- a/tests/try_recv.rs
+++ b/tests/try_recv.rs
@@ -3,7 +3,12 @@ use session_types::*;
 
 use std::thread::spawn;
 
-fn client(n: u64, c: Chan<(), Send<u64, Eps>>) {
+enum Msg {
+    U64(u64)
+}
+
+fn client(n: u64, c: Chan<(), Send<Msg, Eps>, Msg>) {
+    let n = Msg::U64(n);
     c.send(n).close()
 }
 
@@ -21,7 +26,7 @@ fn main() {
 
     let res = c2.try_recv();
     assert!(res.is_ok());
-    let (c, n_) = res.ok().unwrap();
+    let (c, Msg::U64(n_)) = res.ok().unwrap();
     assert_eq!(n, n_);
 
     c.close();


### PR DESCRIPTION
Hi there. Great work on this library, I really like the concept!

I was experimenting with adding a `V` parameter to `Chan` that would allow the user to provide an enum to parametrize the inner channel. I'm not sure why, perhaps as a way to remove the `unsafe` inner sending and receiving?

It did break the inner implemenation of `Choose`, which I solved by adding a `Selectable` trait that would be implemented by the user to provide the `sel1/sel2` values themselves instead of the default `true/false`(in the same enum `V`). 

On the downside, you would definitely loose quite a lot of 'labeling' capacity on the definition of the protocol side, since you end up with a bunch of `Send` and `Recv` that all get this same enum as parameter.  So something descriptive like [`type Paint = Recv<(Vec<PaintRequest>, FrameTreeId), Var<Z>>;`](https://github.com/laumann/servo/commit/d094815aea5571496f33588b2377251734399398#diff-c3dbc39fcc9455f23018f23f77a492fdR206) would be transformed into a much less descriptive `type Paint = Recv<Msg, Var<Z>>;` On the other hand, perhaps some people in some cases would prefer to just define one enums for all messages, instead of separate types for each particular step.

I got as far as making the two simple tests pass, by some miracle I guess. 

Anyway, this is just meant as a way of sharing the results of this experiment. Perhaps  consider adding a second API endpoint with this kind of typing that would include safe sending on the underlying channel for those who require it?
