### PR TITLE
Clean up dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["session", "types", "channels", "concurrency", "communication"]
 license = "MIT"
 
 [dev-dependencies]
-compiletest_rs = "0.3.11"
+compiletest_rs = { version = "0.3.11", features = ["stable"] }
 rand = "0.5.5"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,8 @@ license = "MIT"
 
 [dev-dependencies]
 rand = "*"
+compiletest_rs = "0.3.11"
 
 [features]
 default = []
-chan_select = ["compiletest_rs"]
-
-[dependencies]
-compiletest_rs = { version = "0.3.11", optional = true }
+chan_select = []


### PR DESCRIPTION
compiletest should be a dev dependency and it is also not a requirement for
chan_select to work.