### PR TITLE
Improve unsafe code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,6 @@
 //! }
 //! ```
 #![cfg_attr(feature = "cargo-clippy", allow(type_complexity))]
-
 extern crate crossbeam_channel;
 
 use std::marker;
@@ -185,30 +184,18 @@ impl<E, P> Drop for Chan<E, P> {
 
 impl<E> Chan<E, Eps> {
     /// Close a channel. Should always be used at the end of your program.
-    pub fn close(mut self) {
+    pub fn close(self) {
         // This method cleans up the channel without running the panicky destructor
         // In essence, it calls the drop glue bypassing the `Drop::drop` method
-        use std::mem;
+        use std::{mem, ptr};
 
-        // Create some dummy values to place the real things inside
-        // This is safe because nobody will read these
-        // mem::swap uses a similar technique (also paired with `forget()`)
-        let mut sender = unsafe { mem::uninitialized() };
-        let mut receiver = unsafe { mem::uninitialized() };
+        let this = mem::ManuallyDrop::new(self);
 
-        // Extract the internal sender/receiver so that we can drop them
-        // We cannot drop directly since moving out of a type
-        // that implements `Drop` is disallowed
-        mem::swap(&mut self.0, &mut sender);
-        mem::swap(&mut self.1, &mut receiver);
+        let sender = unsafe { ptr::read(&(this).0 as *const _) };
+        let receiver = unsafe { ptr::read(&(this).1 as *const _) };
 
-        drop(sender);
-        drop(receiver); // drop them
-
-        // Ensure Chan destructors don't run so that we don't panic
-        // This also ensures that the uninitialized values don't get
-        // read at any point
-        mem::forget(self);
+        // drop(sender);
+        // drop(receiver); // drop them
     }
 }
 

--- a/tests/drop_server.rs
+++ b/tests/drop_server.rs
@@ -1,44 +1,39 @@
 extern crate session_types;
 
-#[cfg(test)]
-#[allow(dead_code)]
-mod session_types_tests {
+use session_types::*;
 
-    use std::boxed::Box;
-    use std::error::Error;
-    use std::thread;
-    use session_types::*;
+fn client(c: Chan<(), Send<(), Eps>>) {
+    c.send(()).close();
+}
 
-    fn client(c: Chan<(), Send<(), Eps>>) {
-        c.send(()).close();
-    }
+fn server(c: Chan<(), Recv<(), Eps>>) {
+    let (c, ()) = c.recv();
+    c.close();
+}
 
-    fn server(c: Chan<(), Recv<(), Eps>>) {
-        let (c, ()) = c.recv();
-        c.close();
-    }
+fn drop_client(_c: Chan<(), Send<(), Eps>>) {}
 
-    fn drop_client(_c: Chan<(), Send<(), Eps>>) {}
+fn drop_server(_c: Chan<(), Recv<(), Eps>>) {}
 
-    fn drop_server(_c: Chan<(), Recv<(), Eps>>) {}
+#[test]
+fn server_client_works() {
+    connect(server, client);
+}
 
-    // #[test]
-    fn server_client_works() {
-        connect(server, client);
-    }
+#[test]
+#[should_panic]
+fn client_incomplete_panics() {
+    connect(server, drop_client);
+}
 
-    // #[test]
-    fn client_incomplete_panics() {
-        connect(server, drop_client);
-    }
+#[test]
+#[should_panic]
+fn server_incomplete_panics() {
+    connect(drop_server, client);
+}
 
-    #[test]
-    fn server_incomplete_segfaults() {
-        connect(drop_server, client);
-    }
-
-    // #[test]
-    fn server_client_incomplete_panics() {
-        connect(drop_server, drop_client);
-    }
+#[test]
+#[should_panic]
+fn server_client_incomplete_panics() {
+    connect(drop_server, drop_client);
 }

--- a/tests/drop_server.rs
+++ b/tests/drop_server.rs
@@ -1,0 +1,44 @@
+extern crate session_types;
+
+#[cfg(test)]
+#[allow(dead_code)]
+mod session_types_tests {
+
+    use std::boxed::Box;
+    use std::error::Error;
+    use std::thread;
+    use session_types::*;
+
+    fn client(c: Chan<(), Send<(), Eps>>) {
+        c.send(()).close();
+    }
+
+    fn server(c: Chan<(), Recv<(), Eps>>) {
+        let (c, ()) = c.recv();
+        c.close();
+    }
+
+    fn drop_client(_c: Chan<(), Send<(), Eps>>) {}
+
+    fn drop_server(_c: Chan<(), Recv<(), Eps>>) {}
+
+    // #[test]
+    fn server_client_works() {
+        connect(server, client);
+    }
+
+    // #[test]
+    fn client_incomplete_panics() {
+        connect(server, drop_client);
+    }
+
+    #[test]
+    fn server_incomplete_segfaults() {
+        connect(drop_server, client);
+    }
+
+    // #[test]
+    fn server_client_incomplete_panics() {
+        connect(drop_server, drop_client);
+    }
+}


### PR DESCRIPTION
We used channels on `Box<u8>` when we should have used channels on `*const u8`, otherwise channel destructors attempt to clean up this allocation of a `Box<u8>` and fail.

Fixes #56

Currently requires nightly-only functionality